### PR TITLE
Ensure entry is authored when using promise API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8936,7 +8936,6 @@
       "version": "file:packages/plasmid-core",
       "requires": {
         "ava": "^3.5.2",
-        "docdash": "^1.2.0",
         "eslint": "^6.8.0",
         "hypercore": "^8.11.1",
         "jsonschema": "^1.2.5"
@@ -8949,8 +8948,8 @@
         "cors": "^2.8.5",
         "docdash": "^1.2.0",
         "express": "^4.17.1",
-        "plasmid-core": "^0.0.1",
-        "plasmid-replicator": "^0.0.1",
+        "plasmid-core": "^0.0.3",
+        "plasmid-replicator": "^0.0.3",
         "swagger-jsdoc": "^4.0.0",
         "swagger-ui-express": "^4.1.4"
       }
@@ -8959,7 +8958,6 @@
       "version": "file:packages/plasmid-replicator",
       "requires": {
         "ava": "^3.5.2",
-        "docdash": "^1.2.0",
         "eslint": "^6.8.0",
         "hyperswarm": "^2.10.1"
       }

--- a/packages/plasmid-core/lib/entries.js
+++ b/packages/plasmid-core/lib/entries.js
@@ -46,9 +46,9 @@ function newEntry (author, sequence, timestamp, content = {}, remoteAuthor = und
     author,
     sequence,
     timestamp,
-    content,
-    remoteAuthor
+    content
   }
+  if (remoteAuthor) entry.remoteAuthor = remoteAuthor
   validateEntry(entry) // throws an error if entry not valid
   return entry
 }

--- a/packages/plasmid-core/lib/node.js
+++ b/packages/plasmid-core/lib/node.js
@@ -59,6 +59,11 @@ class Node extends EventEmitter {
     this.readStream = this.feed.createReadStream({ live: true, snapshot: false })
     this.readStream
       .on('data', data => {
+        /**
+         * Emitted every time this node authors an entry to its feed
+         * @event Node#authoredEntry
+         */
+        this.emit('authoredEntry', data)
         switch (data.content.type) {
           case SYS_ENTRIES.SUBSCRIBE:
             this._subscribe(data)
@@ -75,11 +80,6 @@ class Node extends EventEmitter {
           default:
             // a non-system entry was authored
         }
-        /**
-         * Emitted every time this node authors an entry to its feed
-         * @event Node#authoredEntry
-         */
-        this.emit('authoredEntry', data)
       })
   }
 

--- a/packages/plasmid-core/test/subscriptions.js
+++ b/packages/plasmid-core/test/subscriptions.js
@@ -3,6 +3,8 @@ const { newScratchDir } = require('./test-utils')
 const { initNode, subscribe, unsubscribe, head } = require('../lib').promise
 
 const testKey = '0'.repeat(64)
+const testKey2 = '1'.repeat(64)
+
 const expectedSubscribeContent = {
   type: '%subscribe',
   feedKey: testKey,
@@ -45,4 +47,14 @@ test('Can subscribe, unsubscribe, resubsubscribe many times...', async t => {
     t.is(n.foreignFeeds[testKey], undefined)
   }
   t.is(n.feed.length, 2 * nIter)
+})
+
+test('Can subscribe to multiple feeds', async t => {
+  const n = await initNode(newScratchDir())
+  await subscribe(n, testKey, { timestamp: 0 })
+  t.is(n.feed.length, 1)
+  await subscribe(n, testKey2, { timestamp: 0 })
+  t.is(n.feed.length, 2)
+  t.assert(n.foreignFeeds[testKey])
+  t.assert(n.foreignFeeds[testKey2])
 })


### PR DESCRIPTION
There was an issue when using the promise API to subscribe to multiple feeds quickly. The sequence numbers were not updated fast enough.

This fixes the promise API so it fully waits for entries to be authored and sequence number updated before resolving