### PR TITLE
change docker setup to use system networking

### DIFF
--- a/packages/plasmid-daemon/Dockerfile
+++ b/packages/plasmid-daemon/Dockerfile
@@ -13,6 +13,4 @@ RUN npm install
 # # Bundle app source
 COPY . .
 
-EXPOSE 8080
-
-CMD [ "node", "src/index.js", "/var/lib/plasmid-store/", "8080" ]
+CMD [ "node", "src/index.js", "/var/lib/plasmid-store/"]

--- a/packages/plasmid-daemon/README.md
+++ b/packages/plasmid-daemon/README.md
@@ -15,10 +15,12 @@ This will take a while the first time but be very quick after that.
 Run the image using:
 
 ```
-docker run -p 49160:8080 -d <your username>/plasmid-daemon
+docker run --network host \
+    -e PLASMID_HTTP_PORT=3000 \
+    -d <your username>/plasmid-daemon
 ```
 
-To bind it to port `49160`. Chose another port it desired.
+To bind it to port `3000`. Chose another port it desired.
 
 Note this will only use temporary storage. 
 
@@ -33,5 +35,8 @@ docker volume create plasmid-data
 You can then mount this to where plasmid-daemon defaults to storing the data
 
 ```bash
-docker run -p 49160:8080 -v plasmid-data:/var/lib/plasmid-store -d <your username>/plasmid-daemon
+docker run --network host \
+    -e PLASMID_HTTP_PORT=3000 \
+    -v plasmid-data:/var/lib/plasmid-store \
+    -d <your username>/plasmid-daemon
 ```

--- a/packages/plasmid-daemon/src/index.js
+++ b/packages/plasmid-daemon/src/index.js
@@ -25,11 +25,11 @@ async function main () {
     process.exit(1)
   }
   const persistencePath = process.argv[2]
-  if (!process.argv[3]) {
-    console.error('No port provided (second arg)')
+  if (process.argv[3] === undefined && process.env.PLASMID_HTTP_PORT === undefined) {
+    console.error('No port provided (second arg) or PLASMID_HTTP_PORT env var')
     process.exit(1)
   }
-  const port = process.argv[3]
+  const port = process.argv[3] || process.env.PLASMID_HTTP_PORT
   console.log('Setting up node persistence dir...', persistencePath)
   if (!fs.existsSync(persistencePath)) {
     fs.mkdirSync(persistencePath, { recursive: true })


### PR DESCRIPTION
Since hyperswarm uses randomly assigned system ports to connect to peers it is difficult to know what to expose on the docker instance. 

This changes the instructions and setup slightly to use the host networking stack which gets around the issue entirely. Tested successfully networked peers.

This may be an issue deploying to some hosting platforms but cross that bridge when we get to it